### PR TITLE
Arreglo de modificadores de acceso en Superclases e inclusión de toStrings faltantes

### DIFF
--- a/backend/src/main/java/com/unla/grupo19/grupo19OO22023/entities/Dispositivo.java
+++ b/backend/src/main/java/com/unla/grupo19/grupo19OO22023/entities/Dispositivo.java
@@ -27,30 +27,40 @@ public abstract class Dispositivo {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int idDispositivo;
+    protected int idDispositivo;
 
     @Column(nullable = false, length = 50)
-    private String nombre;
+    protected String nombre;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "idZona", nullable = false)
-    private Zona zona;
+    protected Zona zona;
 
     @CreationTimestamp
     @Column(nullable = false)
-    private LocalDateTime fechaHoraCreacion;
+    protected LocalDateTime fechaHoraCreacion;
 
     @UpdateTimestamp
     @Column(nullable = false)
-    private LocalDateTime fechaHoraActualizacion;
+    protected LocalDateTime fechaHoraActualizacion;
 
     @Column(nullable = false)
-    private boolean baja;
+    protected boolean baja;
 
     public Dispositivo(String nombre, Zona zona) {
         this.nombre = nombre;
         this.zona = zona;
         this.baja = false;
+    }
+
+    @Override
+    public String toString(){
+        return "idDispositivo: " + idDispositivo
+                + ", nombre: " + nombre
+                + ", zona: " + zona
+                + ", fechaHoraCreacion: " + fechaHoraCreacion
+                + ", fechaHoraActualizacion: " + fechaHoraActualizacion
+                + ", baja: " + baja;
     }
 
 }

--- a/backend/src/main/java/com/unla/grupo19/grupo19OO22023/entities/Evento.java
+++ b/backend/src/main/java/com/unla/grupo19/grupo19OO22023/entities/Evento.java
@@ -36,4 +36,16 @@ public class Evento {
     @Column(nullable = false)
     private LocalDateTime fechaHoraRegistro;
 
+    public Evento(Dispositivo dispositivo, String descripcion) {
+        this.dispositivo = dispositivo;
+        this.descripcion = descripcion;
+    }
+
+    @Override
+    public String toString(){
+        return "idEvento: " + idEvento
+                + ", dispositivo: " + dispositivo
+                + ", descripcion: " + descripcion
+                + ", fechaHoraRegistro: " + fechaHoraRegistro;
+    }
 }

--- a/backend/src/main/java/com/unla/grupo19/grupo19OO22023/entities/Medicion.java
+++ b/backend/src/main/java/com/unla/grupo19/grupo19OO22023/entities/Medicion.java
@@ -25,20 +25,27 @@ public abstract class Medicion {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int idMedicion;
+    protected int idMedicion;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "idDispositivo", nullable = false)
-    private Dispositivo dispositivo;
+    protected Dispositivo dispositivo;
 
     @CreationTimestamp
     @Column(nullable = false)
-    private LocalDateTime fechaHoraRegistro;
+    protected LocalDateTime fechaHoraRegistro;
 
 
     // CONSTRUCTOR
     public Medicion(Dispositivo dispositivo) {
         this.dispositivo = dispositivo;
+    }
+
+    @Override
+    public String toString(){
+        return "idMedicion: " + idMedicion
+                + ", dispositivo: " + dispositivo
+                + ", fechaHoraRegistro: " + fechaHoraRegistro;
     }
 
 }


### PR DESCRIPTION
- Se paso de `private` a `protected` los atributos de las superclases `Dispositivo` y `Medicion`
- Se añadio los `toString()` faltantes en `Dispositivo`, `Evento` y `Medicion`